### PR TITLE
feat(claude-md): require a PR over a push to the default branch

### DIFF
--- a/skills/claude-md.mjs
+++ b/skills/claude-md.mjs
@@ -11,7 +11,8 @@ const REPO = 'https://github.com/jbarbier/CLAUDE.md'
 const REPLACE = [['Julien', 'Kiko']]
 
 // Upstream is silent on these; agents otherwise narrate every line, treat
-// perf as optional, and open PRs then walk away. Appended, not patched, so
+// perf as optional, push straight to the default branch, and open PRs then
+// walk away. Appended, not patched, so
 // an upstream rewrite cannot drop it.
 const APPEND = `
 ## Performance
@@ -35,6 +36,12 @@ is not clear enough yet.
 - No archaeology. Why the old code was wrong goes in the commit, not above the new code.
 
 ## Pull requests
+
+Ship work as a pull request, never as a push to the default branch. Branch
+first, commit there, open the PR — including for a one-line fix, including
+when the change is obviously correct and the tests are green. A direct push
+skips CI, bot review, and any chance to read the diff in isolation. "It was
+small" is exactly when this gets skipped and exactly when it should not be.
 
 Opening a PR is not the finish line. Stay on it until every review comment is
 addressed — resolved, fixed, or replied with a clear reason — then re-check


### PR DESCRIPTION
Adds a rule to the `APPEND` block in `skills/claude-md.mjs`: ship work as a pull request, never as a push to the default branch.

Prompted by a session where a one-line-ish fix went straight to `master` on microlinkhq/healthcheck — tests green, change correct, but CI and bot review never saw it. The existing "Pull requests" section covered *staying* on a PR after opening one; it assumed a PR existed.

Lives in `APPEND` rather than upstream so a jbarbier/CLAUDE.md rewrite cannot drop it. Rendered to `~/.config/claude-md/CLAUDE.md` and symlinked into Claude Code, Codex, and Cursor by `installClaudeMd`.

`skills/index.mjs` has an unrelated working-tree change (adds `copy-editing`) that is deliberately left out of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7ZWeUyxf9t1rsHUkgGSip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to local agent instructions; no runtime application logic or security-sensitive code paths.
> 
> **Overview**
> Strengthens the **Pull requests** section in the `APPEND` block of `skills/claude-md.mjs`, which is concatenated onto the cloned upstream `CLAUDE.md` and symlinked into Claude Code, Codex, and Cursor via `installClaudeMd`.
> 
> Agents are now told to **ship via pull request only**—branch, commit, open a PR even for tiny or obviously-correct fixes—because a direct push to the default branch skips CI, bot review, and an isolated diff read. The existing guidance about staying on a PR until review and CI are clean is unchanged.
> 
> The file header comment is updated so the listed failure modes include pushing straight to the default branch, not only opening a PR and walking away.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d15cbb65e9d398e067ff2aedf0068b81d84dc490. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->