### PR TITLE
fix(pnpm): keep shim first after brew link

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -9,7 +9,7 @@ end
 # Keep essential user paths in tracked config instead of universal variables.
 # ~/dotfiles/bin first so the pnpm shim wraps Homebrew's binary (`brew link` is fine).
 set -gx PNPM_HOME $HOME/Library/pnpm
-fish_add_path -g -p $HOME/dotfiles/bin $PNPM_HOME/bin /opt/homebrew/sbin /opt/homebrew/bin
+fish_add_path -g -m -p $HOME/dotfiles/bin $PNPM_HOME/bin /opt/homebrew/sbin /opt/homebrew/bin
 
 fzf_configure_bindings \
     --history=\cr \

--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -7,22 +7,10 @@ if status is-interactive
 end
 
 # Keep essential user paths in tracked config instead of universal variables.
-set -l dotfiles_bin "$HOME/dotfiles/bin"
-if test -d /opt/homebrew/bin
-    fish_add_path -g -p /opt/homebrew/bin
-end
-
-if test -d /opt/homebrew/sbin
-    fish_add_path -g -p /opt/homebrew/sbin
-end
-
-if test -d "$dotfiles_bin"
-    fish_add_path -g -p "$dotfiles_bin"
-end
-
-
-set -gx PNPM_HOME /Users/kikobeats/Library/pnpm
-fish_add_path -g "$PNPM_HOME/bin"
+# Shim first so ~/dotfiles/bin/pnpm wraps the real binary (Homebrew is unlinked).
+set -gx PNPM_HOME $HOME/Library/pnpm
+fish_add_path -g -p $HOME/dotfiles/bin $PNPM_HOME/bin /opt/homebrew/sbin /opt/homebrew/bin
+fish_add_path -g -a /opt/homebrew/opt/pnpm/bin
 
 fzf_configure_bindings \
     --history=\cr \

--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -6,11 +6,6 @@ if status is-interactive
     end
 end
 
-# Fish PATH for this machine (Homebrew is not on the default macOS PATH).
-# Agents do not read this file; the pnpm shim is /usr/local/bin/pnpm.
-set -gx PNPM_HOME $HOME/Library/pnpm
-fish_add_path -g -m -p $HOME/dotfiles/bin $PNPM_HOME/bin /opt/homebrew/sbin /opt/homebrew/bin
-
 fzf_configure_bindings \
     --history=\cr \
     --variables=\cv \

--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -6,8 +6,8 @@ if status is-interactive
     end
 end
 
-# Keep essential user paths in tracked config instead of universal variables.
-# ~/dotfiles/bin first so the pnpm shim wraps Homebrew's binary (`brew link` is fine).
+# Fish PATH for this machine (Homebrew is not on the default macOS PATH).
+# Agents do not read this file; the pnpm shim is /usr/local/bin/pnpm.
 set -gx PNPM_HOME $HOME/Library/pnpm
 fish_add_path -g -m -p $HOME/dotfiles/bin $PNPM_HOME/bin /opt/homebrew/sbin /opt/homebrew/bin
 

--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -7,10 +7,9 @@ if status is-interactive
 end
 
 # Keep essential user paths in tracked config instead of universal variables.
-# Shim first so ~/dotfiles/bin/pnpm wraps the real binary (Homebrew is unlinked).
+# ~/dotfiles/bin first so the pnpm shim wraps Homebrew's binary (`brew link` is fine).
 set -gx PNPM_HOME $HOME/Library/pnpm
 fish_add_path -g -p $HOME/dotfiles/bin $PNPM_HOME/bin /opt/homebrew/sbin /opt/homebrew/bin
-fish_add_path -g -a /opt/homebrew/opt/pnpm/bin
 
 fzf_configure_bindings \
     --history=\cr \

--- a/bin/pnpm
+++ b/bin/pnpm
@@ -6,8 +6,8 @@
 # Pass --lockfile to keep the lockfile, or --no-dangerously-allow-all-builds /
 # the bare flag yourself to override either behavior for a single run.
 #
-# Lives on PATH (dotfiles/bin, ahead of the real pnpm) so every shell picks it
-# up — bash (what Claude uses), fish, sh, etc. — without needing to be sourced.
+# Lives at ~/dotfiles/bin/pnpm and is also linked to /usr/local/bin/pnpm so
+# Cursor agents (Homebrew-first PATH) still hit this wrapper.
 #
 # Why the `--config.<key>` form: pnpm v11 dropped the `npm_config_lockfile` env
 # var, and the bare `--no-lockfile` / `--dangerously-allow-all-builds` flags are
@@ -15,18 +15,25 @@
 # override is honored by every command, including link/unlink.
 set -euo pipefail
 
-# Resolve the real pnpm, skipping this shim's own location to avoid recursion.
+# Prefer Homebrew's Cellar path so we don't depend on PATH order.
 self="$(cd "$(dirname "$0")" && pwd -P)/$(basename "$0")"
 real=""
-IFS=: read -ra _dirs <<<"$PATH"
-for d in "${_dirs[@]}"; do
-  cand="$d/pnpm"
+for cand in /opt/homebrew/opt/pnpm/bin/pnpm /usr/local/opt/pnpm/bin/pnpm; do
   [ -x "$cand" ] || continue
-  [ "$(cd "$d" && pwd -P)/pnpm" = "$self" ] && continue
   real="$cand"
   break
 done
-[ -n "$real" ] || { echo "pnpm: real binary not found on PATH" >&2; exit 127; }
+if [ -z "$real" ]; then
+  IFS=: read -ra _dirs <<<"$PATH"
+  for d in "${_dirs[@]}"; do
+    cand="$d/pnpm"
+    [ -x "$cand" ] || continue
+    [ "$(cd "$d" && pwd -P)/pnpm" = "$self" ] && continue
+    real="$cand"
+    break
+  done
+fi
+[ -n "$real" ] || { echo "pnpm: real binary not found" >&2; exit 127; }
 
 mutating=" add install i update up upgrade remove rm uninstall un link ln unlink "
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,5 +3,8 @@
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 brew bundle
 
+# All shells, once. Same idea as Homebrew's /etc/paths.d/homebrew.
+echo "$HOME/dotfiles/bin" | sudo tee /etc/paths.d/dotfiles >/dev/null
+
 ./.macos
 ./link-dropbox.sh

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,6 +5,7 @@ brew bundle
 
 # All shells, once. Same idea as Homebrew's /etc/paths.d/homebrew.
 echo "$HOME/dotfiles/bin" | sudo tee /etc/paths.d/dotfiles >/dev/null
+echo "$HOME/Library/pnpm/bin" | sudo tee /etc/paths.d/pnpm >/dev/null
 
 ./.macos
 ./link-dropbox.sh

--- a/skills/index.mjs
+++ b/skills/index.mjs
@@ -5,7 +5,6 @@ import { installClaudeMd } from './claude-md.mjs'
 
 const SKILLS = [
   'https://github.com/addyosmani/agent-skills --skill code-review-and-quality --skill code-simplification',
-  'https://github.com/alirezarezvani/claude-skills --skill karpathy-coder',
   'https://github.com/anthropics/skills --skill frontend-design --skill internal-comms',
   'https://github.com/brianlovin/claude-config --skill fix-sentry-issues',
   'https://github.com/coreyhaines31/marketingskills --skill ai-seo --skill copywriting --skill schema --skill seo-audit --skill copy-editing',

--- a/sync.sh
+++ b/sync.sh
@@ -24,6 +24,10 @@ main() {
   if [ -e "$target" ] && [ "$(readlink "$link" 2>/dev/null)" != "$target" ]; then
     sudo ln -sfn "$target" "$link"
   fi
+  # New laptops get this from bootstrap.sh; keep it true on sync too.
+  if [ "$(cat /etc/paths.d/dotfiles 2>/dev/null)" != "$HOME/dotfiles/bin" ]; then
+    echo "$HOME/dotfiles/bin" | sudo tee /etc/paths.d/dotfiles >/dev/null
+  fi
   fish
 }
 

--- a/sync.sh
+++ b/sync.sh
@@ -18,6 +18,12 @@ main() {
         --exclude "Caskfile" \
         --exclude "skills/" \
         -av --no-perms . ~
+  # Cursor agents search /usr/local/bin before Homebrew; the shim must win there.
+  target="$HOME/dotfiles/bin/pnpm"
+  link=/usr/local/bin/pnpm
+  if [ -e "$target" ] && [ "$(readlink "$link" 2>/dev/null)" != "$target" ]; then
+    sudo ln -sfn "$target" "$link"
+  fi
   fish
 }
 

--- a/sync.sh
+++ b/sync.sh
@@ -28,6 +28,9 @@ main() {
   if [ "$(cat /etc/paths.d/dotfiles 2>/dev/null)" != "$HOME/dotfiles/bin" ]; then
     echo "$HOME/dotfiles/bin" | sudo tee /etc/paths.d/dotfiles >/dev/null
   fi
+  if [ "$(cat /etc/paths.d/pnpm 2>/dev/null)" != "$HOME/Library/pnpm/bin" ]; then
+    echo "$HOME/Library/pnpm/bin" | sudo tee /etc/paths.d/pnpm >/dev/null
+  fi
   fish
 }
 


### PR DESCRIPTION
## Summary
- Collapse the fish PATH setup. `brew link pnpm` is the intended Homebrew state.
- The shim execs Homebrew's Cellar binary by absolute path, so it does not depend on PATH order.
- `sync.sh` links the shim to `/usr/local/bin/pnpm` (needs sudo once). Cursor agents search that directory before Homebrew, so they still get `--config.lockfile=false`.

## Test plan
- [ ] `brew link pnpm`
- [ ] `sh sync.sh` (sudo for the `/usr/local/bin` symlink) then `exec fish`
- [ ] `which -a pnpm` shows `/usr/local/bin/pnpm` and/or `~/dotfiles/bin/pnpm`, then Homebrew
- [ ] `pnpm --version` prints `11.20.0`
- [ ] `pnpm add` in a repo that should not get a lockfile does not write `pnpm-lock.yaml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local dotfiles/bootstrap changes only; sudo writes to `/etc/paths.d` and `/usr/local/bin`, with no app or security-critical runtime impact.
> 
> **Overview**
> **PATH setup moves out of fish** into macOS `/etc/paths.d` for `~/dotfiles/bin` and `~/Library/pnpm/bin`, written in **`bootstrap.sh`** and kept in sync by **`sync.sh`**. Fish no longer calls `fish_add_path` for Homebrew, dotfiles, or PNPM.
> 
> **The `pnpm` wrapper** now resolves the real binary via fixed Homebrew opt paths (`/opt/homebrew/opt/pnpm/...`, `/usr/local/opt/pnpm/...`) before scanning `PATH`, so it still works when `brew link pnpm` puts Homebrew ahead of the shim. **`sync.sh`** also symlinks the shim to **`/usr/local/bin/pnpm`** so Cursor-style agents that search there first still get lockfile-skipping behavior.
> 
> Removes the **karpathy-coder** entry from the skills install list in **`skills/index.mjs`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05948eecc3a8e592d29fd60fb5aedc400b2de3ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->