### PR TITLE
feat(fish): recording_on / recording_off toggle for autosuggestions

### DIFF
--- a/.config/fish/functions/recording_off.fish
+++ b/.config/fish/functions/recording_off.fish
@@ -1,0 +1,4 @@
+function recording_off --description "Restore inline autosuggestions after screen recording"
+    set -U fish_autosuggestion_enabled 1
+    echo "recording off: autosuggestions restored"
+end

--- a/.config/fish/functions/recording_on.fish
+++ b/.config/fish/functions/recording_on.fish
@@ -1,0 +1,4 @@
+function recording_on --description "Hide inline autosuggestions while screen recording"
+    set -U fish_autosuggestion_enabled 0
+    echo "recording on: autosuggestions hidden"
+end

--- a/README.md
+++ b/README.md
@@ -10,3 +10,16 @@
 git clone https://github.com/Kikobeats/dotfiles && cd dotfiles && ./sync.sh
 ./boostrap.sh
 ```
+
+## Recording mode
+
+Fish shows a grey inline autosuggestion after the cursor, which reads as noise
+in a screen recording. Toggle it off before hitting record, back on after:
+
+```fish
+recording_on   # autosuggestions hidden
+recording_off  # autosuggestions restored
+```
+
+The flag is a universal variable, so every open terminal changes at once and
+the setting survives a restart. Run `./test/recording.sh` to verify.

--- a/sync.sh
+++ b/sync.sh
@@ -17,6 +17,7 @@ main() {
         --exclude "sync.sh" \
         --exclude "Caskfile" \
         --exclude "skills/" \
+        --exclude "test/" \
         -av --no-perms . ~
   # Cursor agents search /usr/local/bin before Homebrew; the shim must win there.
   target="$HOME/dotfiles/bin/pnpm"

--- a/test/recording.sh
+++ b/test/recording.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+functions_dir="$(cd "$(dirname "$0")/../.config/fish/functions" && pwd)"
+sandbox="$(mktemp -d)"
+trap 'rm -rf "$sandbox"' EXIT
+
+mkdir -p "$sandbox/fish/functions"
+cp "$functions_dir"/recording_on.fish "$functions_dir"/recording_off.fish "$sandbox/fish/functions/"
+: > "$sandbox/fish/config.fish"
+
+failures=0
+
+fish_eval() {
+  XDG_CONFIG_HOME="$sandbox" fish -c "$1"
+}
+
+assert_equal() {
+  local description="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "ok - $description"
+  else
+    echo "not ok - $description (expected '$expected', got '$actual')"
+    failures=$((failures + 1))
+  fi
+}
+
+assert_equal "recording_on reports what it did" \
+  "recording on: autosuggestions hidden" "$(fish_eval recording_on)"
+
+assert_equal "recording_on disables autosuggestions" \
+  "0" "$(fish_eval 'echo $fish_autosuggestion_enabled')"
+
+assert_equal "the flag is universal, so already open shells pick it up" \
+  "universal scope" "$(fish_eval 'set --show fish_autosuggestion_enabled' | sed -n 's/.*set in \(universal scope\).*/\1/p')"
+
+assert_equal "recording_on is idempotent" \
+  "0" "$(fish_eval 'recording_on >/dev/null; echo $fish_autosuggestion_enabled')"
+
+assert_equal "recording_off reports what it did" \
+  "recording off: autosuggestions restored" "$(fish_eval recording_off)"
+
+assert_equal "recording_off restores autosuggestions" \
+  "1" "$(fish_eval 'echo $fish_autosuggestion_enabled')"
+
+assert_equal "recording_off is idempotent" \
+  "1" "$(fish_eval 'recording_off >/dev/null; echo $fish_autosuggestion_enabled')"
+
+exit $failures


### PR DESCRIPTION
## What

`recording_on` hides fish's grey inline autosuggestion; `recording_off` brings it back.

```fish
recording_on   # recording on: autosuggestions hidden
recording_off  # recording off: autosuggestions restored
```

## Why

The autosuggestion after the cursor reads as noise in a screen recording. Note the login shell here is fish, not zsh (`dscl . -read /Users/$USER UserShell` → `/opt/homebrew/bin/fish`), so this is fish's `fish_autosuggestion_enabled`.

Set as a universal variable, so every open terminal flips at once and the state survives a restart, instead of only the shell that ran the command.

## Tests

`./test/recording.sh` — 7 assertions in a sandboxed `XDG_CONFIG_HOME`, each in a fresh fish process so it also proves the flag propagates:

```
ok - recording_on reports what it did
ok - recording_on disables autosuggestions
ok - the flag is universal, so already open shells pick it up
ok - recording_on is idempotent
ok - recording_off reports what it did
ok - recording_off restores autosuggestions
ok - recording_off is idempotent
```

`sync.sh` now excludes `test/` so it does not land in `$HOME`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vqPXf6SB4GkHSoBc5Xkub

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dotfiles-only shell UX and docs; no auth, data, or production runtime impact beyond local fish autosuggestion preference.
> 
> **Overview**
> Adds **`recording_on`** and **`recording_off`** fish commands that flip the universal **`fish_autosuggestion_enabled`** flag so grey inline suggestions disappear during screen recordings and return afterward, with short status messages on each toggle.
> 
> The README documents the workflow and points to **`./test/recording.sh`**, which runs seven sandboxed assertions (messages, on/off values, universal scope, idempotency). **`sync.sh`** now excludes **`test/`** so that harness is not copied into **`$HOME`** on sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39fafc6ba48fc1693e798f4c1e671b84117b7fb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->