### PR TITLE
fix(skills): install specification-website from its root index

### DIFF
--- a/skills/index.mjs
+++ b/skills/index.mjs
@@ -23,7 +23,7 @@ const SKILLS = [
   'https://github.com/vercel-labs/agent-browser --skill agent-browser',
   'https://github.com/vercel-labs/agent-skills --skill vercel-react-best-practices',
   'https://github.com/wshobson/agents --skill wcag-audit-patterns',
-  'https://specification.website/.well-known/agent-skills/specification-website/SKILL.md'
+  'https://specification.website --skill specification-website'
 ]
 
 const command = agent =>


### PR DESCRIPTION
## What changed

`skills/index.mjs` pointed at the scoped SKILL.md URL:

```
https://specification.website/.well-known/agent-skills/specification-website/SKILL.md
```

`skills add` treats that path as a *scope* to filter the host's well-known
index by, finds no match, and refuses to fall back to the root index (it
would otherwise install everything the host publishes). Every run of the
installer failed on this one entry.

Replaced with the same form every other entry uses:

```
https://specification.website --skill specification-website
```

## How it was tested

1. Reproduced the failure with the old URL — `No skills found for the scoped path '/.well-known/agent-skills/specification-website/SKILL.md'`.
2. Ran the corrected form for a single agent — installed.
3. Ran the exact command the installer builds (`--agent claude-code --agent cursor --agent codex --agent github-copilot --global --yes`) — installed to `~/.agents/skills/specification-website`, symlinked into `~/.claude/skills/`, SKILL.md frontmatter verified.

Full `node skills/index.mjs` was not run: it wipes and reinstalls all 20 skills,
and the diff cannot reach any other entry.

## Outcome

Installer goes from 19/20 to 20/20 skills; `specification-website` is available
in Claude Code, Cursor, Codex and GitHub Copilot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NvkAAo7hwxvaHTrDYWCKq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change to a skills installer manifest; no runtime app, auth, or data-path impact.
> 
> **Overview**
> Fixes a failing global skills install step by changing how **`specification-website`** is referenced in `skills/index.mjs`.
> 
> The installer entry no longer points at the scoped `SKILL.md` URL (`https://specification.website/.well-known/agent-skills/specification-website/SKILL.md`), which `skills add` misread as a filter scope and aborted with “no skills found.” It now uses the same **`https://specification.website --skill specification-website`** pattern as the other hosts, so the skill installs for Claude Code, Cursor, Codex, and GitHub Copilot and the batch run can reach **20/20** instead of stopping at 19/20.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4040469dee3d740030eeaf8ee69efbf31e1cf6bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->